### PR TITLE
Add git executable to speed up git clone on certain CI platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- Added `git` executable to allow speed up `git clone` on certain CI platforms.
 
 # 2.16.1 (13.11.2019)
 - Helm version set to [2.16.1](https://github.com/helm/helm/releases/tag/v2.16.1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG HELM_URL="https://storage.googleapis.com/kubernetes-helm/${HELM_ARCHIVE}"
 WORKDIR /root
 
 RUN apk -U --no-cache upgrade \
-    && apk add --no-cache ca-certificates bash
+    && apk add --no-cache ca-certificates bash git
 RUN apk add --no-cache -t deps curl \
     && curl -L $KUBECTL_URL -o /usr/local/bin/kubectl \
     && echo "${KUBECTL_CHECKSUM}  /usr/local/bin/kubectl" | sha256sum -c \


### PR DESCRIPTION
The problem that I trying to solve here is a slow deploy jon in CircleCI workflow that was using half of the time to mount CircleCI workspace with results of work from previous jobs in the pipeline. However, all these results are unneeded at this stage and all that I need is just application source code with helm charts. And this can be taken from CircleCI cache:

So, basically, what I want to do is this:
```diff
diff --git a/.circleci/config.yml b/.circleci/config.yml
index 044d6a2e34..737fc43cd6 100644
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,8 +643,13 @@ jobs:
       tag_prefix:
         type: string
     steps:
-    - attach_workspace:
-        at: .
+    # Same as in checkout_code step
+    - restore_cache:
+        keys:
+          - ebay-mag-2-v1-{{ .Branch }}-{{ .Revision }}
+          - ebay-mag-2-v1-{{ .Branch }}
+          - ebay-mag-2-v1
+    - checkout
     - run:
         name: Configure kubectl
         command: |

```

 But due to CircleCI limitations, git clone can't be speed up for images without git, so, some other internal git cloning mechanism is being used instead and it is not faster.

This change increases image size from 98.4 to 113 MB (on my local machine).